### PR TITLE
fix errors when processing files with backslashes in the path

### DIFF
--- a/plugin/fittencode.vim
+++ b/plugin/fittencode.vim
@@ -82,7 +82,7 @@ endfunction
 function! CodeCompletion()
     call ClearCompletion()
 
-    let l:filename = expand('%')
+    let l:filename = substitute(expand('%'), '\\', '/', 'g')
 
     let l:file_content = join(getline(1, '$'), "\n")
     let l:line_num = line('.')

--- a/plugin/fittencode.vim
+++ b/plugin/fittencode.vim
@@ -129,6 +129,10 @@ function! CodeCompletion()
 
     call delete(l:tempfile)
 
+    if !has_key(l:completion_data, 'generated_text')
+        return
+    endif
+
     let l:generated_text = l:completion_data.generated_text
     let l:generated_text = substitute(l:generated_text, '<.endoftext.>', '', 'g')
 


### PR DESCRIPTION
## Problem

When opening a file by dragging in Windows, `fittencode.vim` will report an error.

The log is as follows
```
Messages maintainer: The Vim Project
"C:\Hello" 0L, 0B
Error detected while processing function CodeCompletion:
line   58:
E716: Key not present in Dictionary: "generated_text"
line   59:
E121: Undefined variable: l:generated_text
E116: Invalid arguments for function substitute(l:generated_text, '<.endoftext.>', '', 'g')
line   61:
E121: Undefined variable: l:generated_text
E116: Invalid arguments for function empty(l:generated_text)
line   67:
E121: Undefined variable: l:generated_text
E116: Invalid arguments for function split(l:generated_text, "\n", 1)
line   68:
E121: Undefined variable: l:text
E116: Invalid arguments for function empty(l:text[-1])
line   73:
E121: Undefined variable: text
line   85:
E121: Undefined variable: l:generated_text
```

## Steps to reproduce
- Install latest gvim on Windows from https://github.com/vim/vim-win32-installer
- Install `fittencode.vim`
- Open gvim and drag the file `C:\Hello` to the gvim window
- Press the shortcut key `<c-l>`
- Server returns `{'detail': [{'ctx': {'error': 'Invalid \escape'}, 'type': 'json_invalid', 'msg': 'JSON decode error', 'input': {}, 'loc': ['body', 75]}]}`

## Solution
- Convert backslashes to slashes in the `filename`
- Check if the `completion_data` contains `generated_text` fields

Also Fix #4 