### PR TITLE
feat&fix: provides customization, and fix double indention

### DIFF
--- a/doc/fittencode.vim.txt
+++ b/doc/fittencode.vim.txt
@@ -1,0 +1,46 @@
+*fittencode.vim.txt*    Fitten Code AI Programming Assistant
+
+==============================================================================
+CONTENTS
+
+    Basic Options                               |fitten-options|
+    Advanced Usage                              |fitten-advanced|
+
+==============================================================================
+BASIC OPTIONS                                   *fitten-options*
+
+*g:fitten_accept_no_echo*
+    Set to 1 to disable "Accept" echoing from suggestion acception
+
+    Default value: `0`
+
+*g:fitten_trigger*
+    The key bindings to trigger code completion, i.e., the key sequence
+    `{lhs}` of the mapping to |CodeCompletion()|.
+
+    Default value: `'<C-l>'`
+
+*g:fitten_accept_key*
+    The key bindings to accept code completion, i.e., the key sequence `{lhs}`
+    of the mapping to |FittenAccept()|.
+
+    Set to |v:none| to disable the mapping.
+
+    Default value: `'<Tab>'`
+
+==============================================================================
+ADVANCED USAGE                                  *fitten-advanced*
+
+For advanced users there are functions that you can use in your own mappings:
+
+FittenAcceptable()                              *FittenAcceptable()*
+    Checks if the suggestion can be accepted. i.e., function |FittenAccept()|
+    would accept the suggestion.
+
+    Return value: 0 or 1.
+
+FittenAccept()                                  *FittenAccept()*
+    Accept the suggestion.
+
+==============================================================================
+ vim:tw=78:ft=help:norl:

--- a/doc/fittencode.vim.txt
+++ b/doc/fittencode.vim.txt
@@ -9,24 +9,17 @@ CONTENTS
 ==============================================================================
 BASIC OPTIONS                                   *fitten-options*
 
-*g:fitten_accept_no_echo*
-    Set to 1 to disable "Accept" echoing from suggestion acception
-
-    Default value: `0`
-
 *g:fitten_trigger*
-    The key bindings to trigger code completion, i.e., the key sequence
-    `{lhs}` of the mapping to |CodeCompletion()|.
+    The key bindings to trigger code completion.
 
-    Default value: `'<C-l>'`
+    Default value: `"\<C-l>"`
 
 *g:fitten_accept_key*
-    The key bindings to accept code completion, i.e., the key sequence `{lhs}`
-    of the mapping to |FittenAccept()|.
+    The key bindings to accept code completion. i.e., call |FittenAccept()|.
 
     Set to |v:none| to disable the mapping.
 
-    Default value: `'<Tab>'`
+    Default value: `"\<Tab>"`
 
 ==============================================================================
 ADVANCED USAGE                                  *fitten-advanced*
@@ -34,13 +27,23 @@ ADVANCED USAGE                                  *fitten-advanced*
 For advanced users there are functions that you can use in your own mappings:
 
 FittenAcceptable()                              *FittenAcceptable()*
-    Checks if the suggestion can be accepted. i.e., function |FittenAccept()|
-    would accept the suggestion.
+    Checks if the suggestion can be accepted. i.e., if the return value is 1,
+    then calling function |FittenAccept()| would accept the suggestion.
 
     Return value: 0 or 1.
 
 FittenAccept()                                  *FittenAccept()*
-    Accept the suggestion.
+    Accept the suggestion. This is done in insert mode, and the return value
+    is of no use.
+
+    NOTE: Should only be used halfway in insert mode, like in >
+        imap <Tab> <C-r>=FittenAccept()<CR>
+<
+    Or like in >
+        imap <Tab> <Cmd>call FittenAccept()<CR>
+<
+
+    Return value: ""
 
 ==============================================================================
  vim:tw=78:ft=help:norl:

--- a/plugin/fittencode.vim
+++ b/plugin/fittencode.vim
@@ -163,15 +163,12 @@ function! CodeCompletion()
     let b:fitten_suggestion = l:generated_text
 endfunction
 
-let g:fitten_accept_no_echo = 0
 function! FittenAcceptMain()
-    if g:fitten_accept_no_echo == 0
-        echo "Accept"
-    endif
+    echo "Accept"
     let default = pumvisible() ? "\<C-N>" : "\t"
 
     if mode() !~# '^[iR]' || !exists('b:fitten_suggestion')
-        return default
+        return g:fitten_accept_key == "\t" ? default : g:fitten_accept_key
     endif
 
     let l:text = b:fitten_suggestion
@@ -183,10 +180,15 @@ endfunction
 
 function FittenAccept()
     let l:oldval = &paste
+
     set paste
+
     execute "normal i" . FittenAcceptMain()
+
     let &paste = l:oldval
+
     unl oldval
+
     return ""
 endfunction
 
@@ -195,15 +197,15 @@ function! FittenAcceptable()
 endfunction
 
 if !exists('g:fitten_trigger')
-    let g:fitten_trigger = '<C-l>'
+    let g:fitten_trigger = "\<C-l>"
 endif
 if !exists('g:fitten_accept_key')
-    let g:fitten_accept_key = '<Tab>'
+    let g:fitten_accept_key = "\<Tab>"
 endif
 function! FittenMapping()
-    execute "inoremap" g:fitten_trigger '<Cmd>call CodeCompletion()<CR>'
+    execute "inoremap" keytrans(g:fitten_trigger) '<Cmd>call CodeCompletion()<CR>'
     if g:fitten_accept_key isnot v:none
-        execute 'inoremap' g:fitten_accept_key '<C-r>=FittenAccept()<CR>'
+        execute 'inoremap' keytrans(g:fitten_accept_key) '<C-r>=FittenAccept()<CR>'
     endif
 endfunction
 


### PR DESCRIPTION
Adds options for customization, like trigger keys. Adds vim help files. Options are described in help docs.

For advanced users, provides API for integration with other plugins.

BREAKING CHANGE: 'Accept()' has non-standard name.

'Accept()' is removed. Use 'FittenAccept()' instead.

======

bugfix: double indentation fixed

by setting 'paste' option to disable auto indent

Closes #14