### PR TITLE
fix: converting tabs to spaces in virtual text

### DIFF
--- a/plugin/fittencode.vim
+++ b/plugin/fittencode.vim
@@ -86,11 +86,7 @@ function! CodeCompletion()
 
     let l:file_content = join(getline(1, '$'), "\n")
     let l:line_num = line('.')
-    if getcurpos()[2] == getcurpos()[4]
-        let l:col_num = getcurpos()[2]
-    else
-        let l:col_num = getcurpos()[2] + 1
-    endif
+    let l:col_num = getcurpos()[2]
     
     let l:prefix = join(getline(1, l:line_num - 1), '\n')
     if !empty(l:prefix)
@@ -146,6 +142,7 @@ function! CodeCompletion()
     if empty(l:text[-1])
         call remove(l:text, -1)
     endif
+    let l:text = map(l:text, 'substitute(v:val, "\t", repeat(" ", &ts), "g")')
 
     let l:is_first_line = v:true
     for line in text


### PR DESCRIPTION
- [`getcurpos`](https://vimhelp.org/builtin.txt.html#getcurpos%28%29)
  - > Returns `[0, lnum, col, off, curswant] `
  - > The `curswant` number is the preferred column when moving the cursor **vertically**.
  - We can simplify the logic because there is no vertical manipulation involved in code completion.
  - Also when feeding tab, `getcurpos()[2] + 1` is not the correct number of columns.
- [`prop_add`](https://vimhelp.org/textprop.txt.html)
  - > Any Tab and other control character in the text will be changed to a space. 
  - So when we call `prop_add`, we need to convert the tab to space.

Fix #26 