### PR TITLE
fix: handle newline calculation and clearing completion properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/plugin/fittencode.vim
+++ b/plugin/fittencode.vim
@@ -71,12 +71,7 @@ endfunction
 function! ClearCompletion()
     unlet! b:fitten_suggestion
     call prop_remove({'type': s:hlgroup, 'all': v:true})
-endfunction
-
-function! ClearCompletionByCursorMoved()
-    if col('.') != col('$')
-        call ClearCompletion()
-    endif
+    redraw!
 endfunction
 
 function! CodeCompletion()
@@ -223,7 +218,7 @@ endfunction
 
 augroup fittencode
     autocmd!
-    autocmd CursorMovedI * call ClearCompletionByCursorMoved()
+    autocmd CursorMovedI * call ClearCompletion()
     autocmd InsertLeave  * call ClearCompletion()
     autocmd BufLeave     * call ClearCompletion()
     autocmd ColorScheme,VimEnter * call SetSuggestionStyle()

--- a/plugin/fittencode.vim
+++ b/plugin/fittencode.vim
@@ -184,7 +184,9 @@ function! FittenInsert(text, is_first_line) abort
     endif
     let l:col = col('.')
     let l:oldline = getline(l:line)
-    let l:newline = l:oldline[:l:col-2] . a:text . l:oldline[l:col-1:]
+    let l:prefix = strpart(l:oldline, 0, l:col-1)
+    let l:suffix = strpart(l:oldline, l:col-1)
+    let l:newline = l:prefix . a:text . l:suffix
     call setline(l:line, l:newline)
     call cursor(l:line, l:col + len(a:text))
 endfunction


### PR DESCRIPTION
There are four main changes
- When `l:col` is equal to 1, using `l:oldline[:l:col-2]` to calculate the prefix will become getting the whole `l:oldline` line
- When there is a lot of completion code, if you don't manually trigger the redraw, there will be a lot of `@` symbols on the interface
- There's no need to judge `col('.') != col('$')` because the `CursorMovedI` event will not be triggered when cursor moves forward at the end of the line.
- Ignore the auto-generated `doc/tags` file