### PR TITLE
fix: 修复了tab时无法根据用户设置进行缩进的错误

### DIFF
--- a/plugin/fittencode.vim
+++ b/plugin/fittencode.vim
@@ -6,6 +6,7 @@ if exists("g:loaded_fittencode")
   endif
 let g:loaded_fittencode = 1
 let g:accept_just_now = 0
+let g:fitten_accepted = v:false
 
 let s:hlgroup = 'FittenSuggestion'
 function! SetSuggestionStyle() abort
@@ -193,12 +194,12 @@ endfunction
 
 function! FittenAcceptMain()
     echo "Accept"
-    let default = pumvisible() ? "\<C-N>" : "\t"
 
     if mode() !~# '^[iR]' || !exists('b:fitten_suggestion')
-        return g:fitten_accept_key == "\t" ? default : g:fitten_accept_key
+        return ''
     endif
 
+    let g:fitten_accepted = v:true
     let l:text = b:fitten_suggestion
 
     call ClearCompletion()
@@ -224,16 +225,21 @@ endfunction
 
 function FittenAccept()
     let g:accept_just_now = 2
-    let l:accept = FittenAcceptMain()
-    let l:accept_lines = split(l:accept, "\n", v:true)
+    let g:fitten_accepted = v:false
 
+    let l:accept = FittenAcceptMain()
+    if g:fitten_accepted == v:false
+        let l:feed = g:fitten_accept_key == '\t' ? "\<Tab>" : g:fitten_accept_key
+        call feedkeys(l:feed, 'n')
+        return
+    endif
+
+    let l:accept_lines = split(l:accept, "\n", v:true)
     let l:is_first_line = v:true
     for line in l:accept_lines
         call FittenInsert(line, l:is_first_line)
         let l:is_first_line = v:false
     endfor
-
-    return ""
 endfunction
 
 function! FittenAcceptable()

--- a/plugin/fittencode.vim
+++ b/plugin/fittencode.vim
@@ -6,7 +6,6 @@ if exists("g:loaded_fittencode")
   endif
 let g:loaded_fittencode = 1
 let g:accept_just_now = 0
-let g:fitten_accepted = v:false
 
 let s:hlgroup = 'FittenSuggestion'
 function! SetSuggestionStyle() abort
@@ -199,7 +198,6 @@ function! FittenAcceptMain()
         return ''
     endif
 
-    let g:fitten_accepted = v:true
     let l:text = b:fitten_suggestion
 
     call ClearCompletion()
@@ -225,11 +223,11 @@ endfunction
 
 function FittenAccept()
     let g:accept_just_now = 2
-    let g:fitten_accepted = v:false
 
     let l:accept = FittenAcceptMain()
-    if g:fitten_accepted == v:false
-        let l:feed = g:fitten_accept_key == '\t' ? "\<Tab>" : g:fitten_accept_key
+    if empty(l:accept)
+        let l:feed = pumvisible() ? "\<C-N>" : "\<Tab>"
+        let l:feed = g:fitten_accept_key == '\t' ? l:feed : g:fitten_accept_key
         call feedkeys(l:feed, 'n')
         return
     endif


### PR DESCRIPTION
当用户键入tab时，若无可接受的补全，理应根据用户设置进行缩进。

但是直接填入\t实际上会破坏用户设置的缩进。用户有可能使用了多个空格来替代一个制表符。
因此，改为使用feedkey填入不同的值。

另外，删除了一些实际上无法用到的返回值